### PR TITLE
Rewrite Archlinux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ A simple shell script that surfaces clipboard history from clipster in Rofi
 
 ## Run
 
-    ./roficlip
+```bash
+./roficlip
+```
 
 ## Arch Linux
 
 AUR - https://aur.archlinux.org/packages/roficlip
 
-    yaourt -S roficlip
+```bash
+$ git clone https://aur.archlinux.org/roficlip.git
+$ cd roficlip
+$ makepkg -si
+```


### PR DESCRIPTION
Let's [not](https://wiki.archlinux.org/index.php/AUR_helpers#Pacman_wrappers) recommend yaourt and also not recommend any other AUR helper. 

Added instructions on how to manually build the package according to the [official instructions](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages).